### PR TITLE
Fix PyTorch 2.x compatibility: Remove deprecated range parameter from…

### DIFF
--- a/pytorch/pytorch-deeplab_v3_plus/utils/summaries.py
+++ b/pytorch/pytorch-deeplab_v3_plus/utils/summaries.py
@@ -15,9 +15,13 @@ class TensorboardSummary(object):
     def visualize_image(self, writer, dataset, image, target, output, global_step):
         grid_image = make_grid(image[:3].clone().cpu().data, 3, normalize=True)
         writer.add_image('Image', grid_image, global_step)
-        grid_image = make_grid(decode_seg_map_sequence(torch.max(output[:3], 1)[1].detach().cpu().numpy(),
-                                                       dataset=dataset), 3, normalize=False, range=(0, 255))
+        
+        pred_seg = decode_seg_map_sequence(torch.max(output[:3], 1)[1].detach().cpu().numpy(), dataset=dataset)
+        pred_seg_tensor = torch.from_numpy(pred_seg).float() / 255.0
+        grid_image = make_grid(pred_seg_tensor, 3, normalize=False)
         writer.add_image('Predicted label', grid_image, global_step)
-        grid_image = make_grid(decode_seg_map_sequence(torch.squeeze(target[:3], 1).detach().cpu().numpy(),
-                                                       dataset=dataset), 3, normalize=False, range=(0, 255))
+        
+        gt_seg = decode_seg_map_sequence(torch.squeeze(target[:3], 1).detach().cpu().numpy(), dataset=dataset)
+        gt_seg_tensor = torch.from_numpy(gt_seg).float() / 255.0
+        grid_image = make_grid(gt_seg_tensor, 3, normalize=False)
         writer.add_image('Groundtruth label', grid_image, global_step)


### PR DESCRIPTION
… make_grid()

- Remove range=(0, 255) parameter from make_grid() calls in summaries.py
- Add manual normalization by dividing by 255.0 and converting to float tensor
- Ensures compatibility with PyTorch 2.x while maintaining visualization functionality
- Fixes TypeError: make_grid() got an unexpected keyword argument 'range'

## Summary by Sourcery

Update image summary visualization for PyTorch 2.x by removing deprecated 'range' argument from make_grid and manually normalizing segmentation maps

Bug Fixes:
- Remove unsupported 'range' parameter from make_grid calls to resolve TypeError in PyTorch 2.x
- Add manual normalization of predicted and ground truth segmentation map tensors by dividing by 255 and converting to float to preserve visualization