### PR TITLE
Fix tensor conversion error in visualization code

### DIFF
--- a/pytorch/pytorch-deeplab_v3_plus/utils/summaries.py
+++ b/pytorch/pytorch-deeplab_v3_plus/utils/summaries.py
@@ -17,11 +17,11 @@ class TensorboardSummary(object):
         writer.add_image('Image', grid_image, global_step)
         
         pred_seg = decode_seg_map_sequence(torch.max(output[:3], 1)[1].detach().cpu().numpy(), dataset=dataset)
-        pred_seg_tensor = torch.from_numpy(pred_seg).float() / 255.0
+        pred_seg_tensor = pred_seg.float() / 255.0
         grid_image = make_grid(pred_seg_tensor, 3, normalize=False)
         writer.add_image('Predicted label', grid_image, global_step)
         
         gt_seg = decode_seg_map_sequence(torch.squeeze(target[:3], 1).detach().cpu().numpy(), dataset=dataset)
-        gt_seg_tensor = torch.from_numpy(gt_seg).float() / 255.0
+        gt_seg_tensor = gt_seg.float() / 255.0
         grid_image = make_grid(gt_seg_tensor, 3, normalize=False)
         writer.add_image('Groundtruth label', grid_image, global_step)


### PR DESCRIPTION
- Remove torch.from_numpy() calls since decode_seg_map_sequence() already returns Tensor
- Fixes TypeError: expected np.ndarray (got Tensor) in summaries.py line 20
- Ensures training can proceed past visualization step in PyTorch 2.x